### PR TITLE
only run JS tests for single plugin if PLUGIN_NAME is defined

### DIFF
--- a/scripts/bash/run_tests.sh
+++ b/scripts/bash/run_tests.sh
@@ -30,7 +30,11 @@ if [ -n "$TEST_SUITE" ]; then
     fi
     exit $vuestatus
   elif [ "$TEST_SUITE" = "JS" ]; then
-    ./console tests:run-js --matomo-url='http://localhost'
+    if [ -n "$PLUGIN_NAME" ]; then
+      ./console tests:run-js --matomo-url='http://localhost' --plugin=$PLUGIN_NAME
+    else
+      ./console tests:run-js --matomo-url='http://localhost'
+    fi
   elif [ "$TEST_SUITE" = "UI" ]; then
     if [ -n "$PLUGIN_NAME" ]; then
       ./console tests:run-ui --persist-fixture-data --assume-artifacts --plugin=$PLUGIN_NAME --extra-options="$UITEST_EXTRA_OPTIONS"


### PR DESCRIPTION
### Description:

Using the new `--plugin=...` parameter to make sure plugin builds only run tests for their specific plugin, so failures in other plugins do not affect the plugin build's status.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
