### PR TITLE
Enable Testomatio reporter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -79,6 +79,10 @@ inputs:
     description: "Additional setup script to run before starting tests. Can be used by plugin to e.g. set up LDAP or similar."
     required: false
     default: ''
+  testomatio:
+    description: "To enable Testomat.io reporter for tests, Testomat.io token should be set via this input"
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -208,6 +212,7 @@ runs:
         PHPUNIT_EXTRA_OPTIONS: ${{ inputs.phpunit-test-options }}
         GITHUB_BRANCH: ${{ github.head_ref || github.ref_name }}
         MYSQL_ADAPTER: ${{ inputs.mysql-driver }}
+        TESTOMATIO: ${{ inputs.testomatio }}
         TRAVIS: '1'
 
     - name: Debug informations


### PR DESCRIPTION
### Description:

To enable Testomatio reporter to send test results to https://app.testomat.io we need to pass in `TESTOMATIO` environment variable. This variable should be passed as input as depending on a type of tests (unit, UI) tests need to be reported into the different projects, that's why value of `TESTOMATIO` will be different.

If `TESTOMATIO` variable is set and the corresponding Testomatio reporter (mocha or PHPUnit) is enabled, run results will be sent automatically.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
