### PR TITLE
Allow using MariaDb instead of MySQL for tests

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,13 @@ inputs:
     description: "If true a MySQL 5.7 will be set up"
     required: false
     default: true
+  mysql-schema:
+    description: "MySQL database schema to use. Can be Mysql or Mariadb"
+    options:
+      - Mysql
+      - Mariadb
+    required: false
+    default: 'Mysql'
   matomo-test-branch:
     description: "Branch or tag name of Matomo to run plugin tests for. This can be either a specific name or maximum_supported_matomo or minimum_required_matomo."
     required: false
@@ -89,10 +96,18 @@ runs:
   steps:
 
     - name: start mysql services
-      if: inputs.mysql-service == 'true'
+      if: inputs.mysql-service == 'true' && inputs.mysql-schema == 'Mysql'
       shell: bash
       run: |
         docker run -d --tmpfs /var/lib/mysql:rw --tmpfs /bitnami/mysql/data:rw -v ${{ github.action_path }}/artifacts/my.cnf:/opt/bitnami/mysql/conf/my_custom.cnf:ro --name mysql -p 3306:3306 -e ALLOW_EMPTY_PASSWORD=yes -e MYSQL_DATABASE=matomo_tests bitnami/mysql:5.7
+        sleep 10
+        mysql -h127.0.0.1 -uroot -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES';SET GLOBAL wait_timeout = 36000;SET GLOBAL max_allowed_packet = 134209536;"
+
+    - name: start mariadb services
+      if: inputs.mysql-service == 'true' && inputs.mysql-schema == 'Mariadb'
+      shell: bash
+      run: |
+        docker run -d --tmpfs /var/lib/mariadb:rw --tmpfs /bitnami/mariadb/data:rw -v ${{ github.action_path }}/artifacts/my.cnf:/opt/bitnami/mariadb/conf/my_custom.cnf:ro --name mariadb -p 3306:3306 -e ALLOW_EMPTY_PASSWORD=yes -e MARIADB_DATABASE=matomo_tests bitnami/mariadb:latest
         sleep 10
         mysql -h127.0.0.1 -uroot -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES';SET GLOBAL wait_timeout = 36000;SET GLOBAL max_allowed_packet = 134209536;"
 
@@ -179,6 +194,7 @@ runs:
         TEST_SUITE: ${{ inputs.test-type }}
         MATOMO_TEST_TARGET: ${{ inputs.matomo-test-branch }}
         MYSQL_ADAPTER: ${{ inputs.mysql-driver }}
+        MYSQL_SCHEMA: ${{ inputs.mysql-schema }}
         PLUGIN_NAME: ${{ inputs.plugin-name }}
         WORKSPACE: ${{ github.workspace }}
         ACTION_PATH: ${{ github.action_path }}
@@ -222,6 +238,7 @@ runs:
         PHPUNIT_EXTRA_OPTIONS: ${{ inputs.phpunit-test-options }}
         GITHUB_BRANCH: ${{ github.head_ref || github.ref_name }}
         MYSQL_ADAPTER: ${{ inputs.mysql-driver }}
+        MYSQL_SCHEMA: ${{ inputs.mysql-schema }}
         TESTOMATIO: ${{ inputs.testomatio }}
         TESTOMATIO_CREATE: 1
         TRAVIS: '1'

--- a/action.yml
+++ b/action.yml
@@ -55,11 +55,11 @@ inputs:
     default: false
   mysql-service:
     type: boolean
-    description: "If true a MySQL 5.7 will be set up"
+    description: "If true a MySQL engine will be set up. "
     required: false
     default: true
-  mysql-schema:
-    description: "MySQL database schema to use. Can be Mysql or Mariadb"
+  mysql-engine:
+    description: "MySQL database engine to use. Can be 'Mysql' or 'Mariadb'"
     options:
       - Mysql
       - Mariadb
@@ -96,7 +96,7 @@ runs:
   steps:
 
     - name: start mysql services
-      if: inputs.mysql-service == 'true' && inputs.mysql-schema == 'Mysql'
+      if: inputs.mysql-service == 'true' && inputs.mysql-engine == 'Mysql'
       shell: bash
       run: |
         docker run -d --tmpfs /var/lib/mysql:rw --tmpfs /bitnami/mysql/data:rw -v ${{ github.action_path }}/artifacts/my.cnf:/opt/bitnami/mysql/conf/my_custom.cnf:ro --name mysql -p 3306:3306 -e ALLOW_EMPTY_PASSWORD=yes -e MYSQL_DATABASE=matomo_tests bitnami/mysql:5.7
@@ -104,7 +104,7 @@ runs:
         mysql -h127.0.0.1 -uroot -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES';SET GLOBAL wait_timeout = 36000;SET GLOBAL max_allowed_packet = 134209536;"
 
     - name: start mariadb services
-      if: inputs.mysql-service == 'true' && inputs.mysql-schema == 'Mariadb'
+      if: inputs.mysql-service == 'true' && inputs.mysql-engine == 'Mariadb'
       shell: bash
       run: |
         docker run -d --tmpfs /var/lib/mariadb:rw --tmpfs /bitnami/mariadb/data:rw -v ${{ github.action_path }}/artifacts/my.cnf:/opt/bitnami/mariadb/conf/my_custom.cnf:ro --name mariadb -p 3306:3306 -e ALLOW_EMPTY_PASSWORD=yes -e MARIADB_DATABASE=matomo_tests bitnami/mariadb:latest
@@ -194,7 +194,7 @@ runs:
         TEST_SUITE: ${{ inputs.test-type }}
         MATOMO_TEST_TARGET: ${{ inputs.matomo-test-branch }}
         MYSQL_ADAPTER: ${{ inputs.mysql-driver }}
-        MYSQL_SCHEMA: ${{ inputs.mysql-schema }}
+        MYSQL_ENGINE: ${{ inputs.mysql-engine }}
         PLUGIN_NAME: ${{ inputs.plugin-name }}
         WORKSPACE: ${{ github.workspace }}
         ACTION_PATH: ${{ github.action_path }}
@@ -238,7 +238,7 @@ runs:
         PHPUNIT_EXTRA_OPTIONS: ${{ inputs.phpunit-test-options }}
         GITHUB_BRANCH: ${{ github.head_ref || github.ref_name }}
         MYSQL_ADAPTER: ${{ inputs.mysql-driver }}
-        MYSQL_SCHEMA: ${{ inputs.mysql-schema }}
+        MYSQL_ENGINE: ${{ inputs.mysql-engine }}
         TESTOMATIO: ${{ inputs.testomatio }}
         TESTOMATIO_CREATE: 1
         TRAVIS: '1'

--- a/artifacts/config.ini.github.php
+++ b/artifacts/config.ini.github.php
@@ -9,6 +9,7 @@ password =
 ; we need to use piwik_tests here, as otherwise tests will fail for Matomo 4 versions before the rename
 dbname = piwik_tests
 adapter = PDO_MYSQL
+schema = Mysql
 ; no table prefix for tests on GitHub
 tables_prefix =
 ;charset = utf8
@@ -23,6 +24,7 @@ username = root
 password =
 dbname = piwik_tests
 adapter = PDO_MYSQL
+schema = Mysql
 ; no table prefix for tests on GitHub
 tables_prefix =
 

--- a/scripts/bash/prepare.sh
+++ b/scripts/bash/prepare.sh
@@ -43,7 +43,7 @@ if [ "$PHP_VERSION" = "8.1" ] || [ "$PHP_VERSION" = "8.2" ] || [ "$PHP_VERSION" 
 fi
 
 # setup config
-sed "s/PDO_MYSQL/$MYSQL_ADAPTER/g; s/schema = Mysql/schema = $MYSQL_SCHEMA/g" $ACTION_PATH/artifacts/config.ini.github.php >config/config.ini.php
+sed "s/PDO_MYSQL/$MYSQL_ADAPTER/g; s/schema = Mysql/schema = $MYSQL_ENGINE/g" $ACTION_PATH/artifacts/config.ini.github.php >config/config.ini.php
 
 # for plugin builds on minimal required matomo version disable deprecation notices
 if [ "$PLUGIN_NAME" != '' ] && [ "$MATOMO_TEST_TARGET" == "minimum_required_matomo" ]; then

--- a/scripts/bash/prepare.sh
+++ b/scripts/bash/prepare.sh
@@ -43,7 +43,7 @@ if [ "$PHP_VERSION" = "8.1" ] || [ "$PHP_VERSION" = "8.2" ] || [ "$PHP_VERSION" 
 fi
 
 # setup config
-sed "s/PDO_MYSQL/$MYSQL_ADAPTER/g" $ACTION_PATH/artifacts/config.ini.github.php >config/config.ini.php
+sed "s/PDO_MYSQL/$MYSQL_ADAPTER/g; s/schema = Mysql/schema = $MYSQL_SCHEMA/g" $ACTION_PATH/artifacts/config.ini.github.php >config/config.ini.php
 
 # for plugin builds on minimal required matomo version disable deprecation notices
 if [ "$PLUGIN_NAME" != '' ] && [ "$MATOMO_TEST_TARGET" == "minimum_required_matomo" ]; then


### PR DESCRIPTION
### Description:

As we officially support MariaDb it might be useful to run some of our tests with MariaDb instead of MySQL to discover possible incompatibilities earlier. 

This PR will allow a test action to decide which database to use.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
