### PR TITLE
Allow using TiDb as database

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,10 +59,11 @@ inputs:
     required: false
     default: true
   mysql-engine:
-    description: "MySQL database engine to use. Can be 'Mysql' or 'Mariadb'"
+    description: "MySQL database engine to use. Can be 'Mysql', 'Mariadb' or 'Tidb'"
     options:
       - Mysql
       - Mariadb
+      - Tidb
     required: false
     default: 'Mysql'
   matomo-test-branch:
@@ -110,6 +111,14 @@ runs:
         docker run -d --tmpfs /var/lib/mariadb:rw --tmpfs /bitnami/mariadb/data:rw -v ${{ github.action_path }}/artifacts/my.cnf:/opt/bitnami/mariadb/conf/my_custom.cnf:ro --name mariadb -p 3306:3306 -e ALLOW_EMPTY_PASSWORD=yes -e MARIADB_DATABASE=matomo_tests bitnami/mariadb:latest
         sleep 10
         mysql -h127.0.0.1 -uroot -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES';SET GLOBAL wait_timeout = 36000;SET GLOBAL max_allowed_packet = 134209536;"
+
+    - name: start tidb services
+      if: inputs.mysql-service == 'true' && inputs.mysql-engine == 'Tidb'
+      shell: bash
+      run: |
+        docker run -d -p 3306:4000 pingcap/tidb:latest
+        sleep 10
+        mysql -h127.0.0.1 -uroot -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES';SET GLOBAL wait_timeout = 36000;SET GLOBAL max_allowed_packet = 134209536;CREATE DATABASE matomo_tests;"
 
     - name: start redis serivces
       if: inputs.redis-service == 'true'


### PR DESCRIPTION
### Description:

We might need to check if there is a simple way to speed up the performance of TiDb, but we can do that in a later PR as well.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
