### PR TITLE
Change scope of variable to be accessed by child procs

### DIFF
--- a/scripts/bash/run_tests.sh
+++ b/scripts/bash/run_tests.sh
@@ -19,9 +19,9 @@ function should_report_to_testomatio {
 
 should_report_to_testomatio
 if [ $? -eq 0 ]; then
-  SHOULD_SEND_TO_TESTOMATIO=true
+  export SHOULD_SEND_TO_TESTOMATIO=true
 else
-  SHOULD_SEND_TO_TESTOMATIO=false
+  export SHOULD_SEND_TO_TESTOMATIO=false
 fi
 
 if [ -n "$TEST_SUITE" ]; then


### PR DESCRIPTION
### Description:

For non-ui tests this variable is available, however for the UI tests the variable isn't set therefore meaning the UI tests aren't being sent to testomatio anymore.

It's a scoping issue.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
