### PR TITLE
Wait up to 30 seconds for database container to be ready

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -104,8 +104,23 @@ runs:
       if: inputs.mysql-service == 'true' && inputs.mysql-engine == 'Mysql'
       shell: bash
       run: |
-        docker run -d --tmpfs /var/lib/mysql:rw --tmpfs /bitnami/mysql/data:rw -v ${{ github.action_path }}/artifacts/my.cnf:/opt/bitnami/mysql/conf/my_custom.cnf:ro --name mysql -p 3306:3306 -e ALLOW_EMPTY_PASSWORD=yes -e MYSQL_DATABASE=matomo_tests bitnami/mysql:${{ inputs.mysql-version || '5.7' }}
-        sleep 10
+        docker run -d \
+          --tmpfs /var/lib/mysql:rw \
+          --tmpfs /bitnami/mysql/data:rw \
+          -v ${{ github.action_path }}/artifacts/my.cnf:/opt/bitnami/mysql/conf/my_custom.cnf:ro \
+          --name mysql \
+          -p 3306:3306 \
+          -e ALLOW_EMPTY_PASSWORD=yes \
+          -e MYSQL_DATABASE=matomo_tests \
+          bitnami/mysql:${{ inputs.mysql-version || '5.7' }}
+
+        for i in $(seq 1 30); do
+          if mysqladmin ping -h127.0.0.1 -uroot --silent; then
+            break
+          fi
+          sleep 1
+        done
+
         mysql -h127.0.0.1 -uroot -e "
           SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES';
           SET GLOBAL wait_timeout = 36000;
@@ -117,8 +132,23 @@ runs:
       if: inputs.mysql-service == 'true' && inputs.mysql-engine == 'Mariadb'
       shell: bash
       run: |
-        docker run -d --tmpfs /var/lib/mariadb:rw --tmpfs /bitnami/mariadb/data:rw -v ${{ github.action_path }}/artifacts/my.cnf:/opt/bitnami/mariadb/conf/my_custom.cnf:ro --name mariadb -p 3306:3306 -e ALLOW_EMPTY_PASSWORD=yes -e MARIADB_DATABASE=matomo_tests bitnami/mariadb:${{ inputs.mysql-version || 'latest' }}
-        sleep 10
+        docker run -d \
+          --tmpfs /var/lib/mariadb:rw \
+          --tmpfs /bitnami/mariadb/data:rw \
+          -v ${{ github.action_path }}/artifacts/my.cnf:/opt/bitnami/mariadb/conf/my_custom.cnf:ro \
+          --name mariadb \
+          -p 3306:3306 \
+          -e ALLOW_EMPTY_PASSWORD=yes \
+          -e MARIADB_DATABASE=matomo_tests \
+          bitnami/mariadb:${{ inputs.mysql-version || 'latest' }}
+
+        for i in $(seq 1 30); do
+          if mysqladmin ping -h127.0.0.1 -uroot --silent; then
+            break
+          fi
+          sleep 1
+        done
+
         mysql -h127.0.0.1 -uroot -e "
           SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES';
           SET GLOBAL wait_timeout = 36000;
@@ -130,8 +160,17 @@ runs:
       if: inputs.mysql-service == 'true' && inputs.mysql-engine == 'Tidb'
       shell: bash
       run: |
-        docker run -d -p 3306:4000 pingcap/tidb:${{ inputs.mysql-version || 'latest' }}
-        sleep 10
+        docker run -d \
+          -p 3306:4000 \
+          pingcap/tidb:${{ inputs.mysql-version || 'latest' }}
+
+        for i in $(seq 1 30); do
+          if mysqladmin ping -h127.0.0.1 -uroot --silent; then
+            break
+          fi
+          sleep 1
+        done
+
         mysql -h127.0.0.1 -uroot -e "
           SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES';
           SET GLOBAL wait_timeout = 36000;


### PR DESCRIPTION
### Description:

For CI runs with a database container the action allows a startup time of max 10 seconds.

If the database takes longer than that, e.g. MySQL 8 often does, the CI run will fail:

> ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 2

This PR changes that behaviour to wait for up to 30 seconds by checking for connectivity once per second. Should be long enough for the database to be ready for the following configuration.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
