### PR TITLE
Add flag to allow more frequent testomat reports

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -95,6 +95,10 @@ inputs:
     description: "To enable Testomat.io reporter for tests, Testomat.io token should be set via this input"
     required: false
     default: ''
+  testomatio-force-report:
+    description: "Flag for whether to force uploading a report to Testomat.io. This can be conditional based on the type of test and trigger."
+    required: false
+    default: false
 
 runs:
   using: "composite"
@@ -312,6 +316,7 @@ runs:
         MYSQL_VERSION: ${{ inputs.mysql-version }}
         TESTOMATIO: ${{ inputs.testomatio }}
         TESTOMATIO_CREATE: 1
+        TESTOMATIO_FORCE_REPORT: ${{ inputs.testomatio-force-report }}
         TESTOMATIO_ENV: PHP-${{ inputs.php-version }}, ${{ inputs.mysql-driver }}, ${{ inputs.mysql-engine }}
         TRAVIS: '1'
 

--- a/action.yml
+++ b/action.yml
@@ -96,7 +96,7 @@ inputs:
     required: false
     default: ''
   testomatio-force-report:
-    description: "Flag for whether to force uploading a report to Testomat.io. This can be conditional based on the type of test and trigger."
+    description: "Flag for whether to force uploading a report to Testomat.io instead of just push events. Only applies if the 'testomatio' token is set."
     required: false
     default: false
 

--- a/scripts/bash/run_tests.sh
+++ b/scripts/bash/run_tests.sh
@@ -7,6 +7,9 @@ function should_report_to_testomatio {
   if [ -v "$TESTOMATIO" ]; then
     return 1 # Return false
   fi
+  if [ "$TESTOMATIO_FORCE_REPORT" == "true" ]; then
+    return 0 # Return true since the token is set and the test was marked as force
+  fi
   if [ "$GITHUB_IS_TRIGGERED_BY_PUSH" == "false" ]; then
     return 1  # Return false
   fi


### PR DESCRIPTION
### Description:

I noticed that we're not getting good flaky test analysis for many of our plugins because uploading reports to Testomat.io was limited to Github push events. Since many of our plugins aren't updated frequently, this means that we no longer have data on which tests are flaky. This PR adds an optional property to allow plugins to upload reports more frequently, like when the workflow is triggered by a schedule (github.event_name == 'push').

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
