### PR TITLE
Use bitnamisecure redis docker images

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -181,12 +181,12 @@ runs:
           CREATE DATABASE matomo_tests;
         "
 
-    - name: start redis serivces
+    - name: start redis services
       if: inputs.redis-service == 'true'
       shell: bash
       run: |
-        docker run -d --name redis -e ALLOW_EMPTY_PASSWORD=yes -p 6379:6379 bitnami/redis:latest
-        docker run -d --name mymaster -e REDIS_MASTER_HOST=localhost -p 26379:26379 bitnami/redis-sentinel:latest
+        docker run -d --name redis -e ALLOW_EMPTY_PASSWORD=yes -p 6379:6379 bitnamisecure/redis:latest
+        docker run -d --name mymaster -e REDIS_MASTER_HOST=localhost -p 26379:26379 bitnamisecure/redis-sentinel:latest
 
     - name: Setup PHP
       if: inputs.php-version != ''


### PR DESCRIPTION
### Description:

Bitnami is retiring their [public container catalog](https://hub.docker.com/u/bitnami), with some images (`redis` and `redis-sentinel` in particular) in the future being published in the [Bitnami Secure repository](https://hub.docker.com/r/bitnamisecure).

A core CI run with the changed images can be found here: https://github.com/matomo-org/matomo/actions/runs/17809821479

_The database containers have already been migrated to official vendor images._

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
