### PR TITLE
Fix for PHPUnit issue

### DIFF
--- a/scripts/bash/prepare.sh
+++ b/scripts/bash/prepare.sh
@@ -40,7 +40,9 @@ composer install --ignore-platform-reqs
 # use PHPUnit 9.x for PHP 8.x
 if [[ "$PHP_VERSION" == "8."* ]]; then
   composer remove --dev phpunit/phpunit
-  composer require --dev phpunit/phpunit ~9.3 --ignore-platform-reqs
+  # made sure that phpunit version chooses 1.5.0 for doctrine/instantiator
+  # because the next version 2.0 introduces incompatible code to php 8.2
+  composer require --dev phpunit/phpunit ~9.3 doctrine/instantiator:^1.5.0 --ignore-platform-reqs
 fi
 
 # setup config


### PR DESCRIPTION
### Description

We had issues with our PHP Tests where failing suddenly without some big changes in our end. 
After some investigations, we found out that after Phpunit version 9.5.27, it already allowed for doctrine/instantiator to go to version ~2.0 and this was causing our tests to fail for PHP8.2. 

The root cause was that doctrine/instantiator 2.0 introduced typed class constants which was only available after PHP 8.3

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
