### PR TITLE
Report to Testomat on schedule events (not push) using event-name gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ This action is able to run certain test suites for Matomo or any Matomo plugin.
     Additional options to provide for PHPUnit tests. This can be used to provide debugging options for PHPUnit.
 
 
+  * **testomatio**
+
+    Testomat.io API token. If set, reports can be uploaded when the workflow is triggered by `schedule`.
+
+
+  * **testomatio-force-report**
+
+    Forces uploading a report to Testomat.io regardless of event trigger. This only applies when `testomatio` is set.
+
+
 ### Example usage for a Plugin
 ```yaml
   PluginTests:

--- a/action.yml
+++ b/action.yml
@@ -96,7 +96,7 @@ inputs:
     required: false
     default: ''
   testomatio-force-report:
-    description: "Flag for whether to force uploading a report to Testomat.io instead of just push events. Only applies if the 'testomatio' token is set."
+    description: "Flag for whether to force uploading a report to Testomat.io instead of default event gating. Only applies if the 'testomatio' token is set."
     required: false
     default: false
 
@@ -332,7 +332,7 @@ runs:
         UITEST_EXTRA_OPTIONS: ${{ inputs.ui-test-options }}
         PHPUNIT_EXTRA_OPTIONS: ${{ inputs.phpunit-test-options }}
         GITHUB_BRANCH: ${{ github.head_ref || github.ref_name }}
-        GITHUB_IS_TRIGGERED_BY_PUSH: ${{ github.event_name == 'push' && 'true' || 'false' }}
+        GITHUB_EVENT_NAME: ${{ github.event_name }}
         MYSQL_ADAPTER: ${{ inputs.mysql-driver }}
         MYSQL_ENGINE: ${{ inputs.mysql-engine }}
         MYSQL_VERSION: ${{ inputs.mysql-version }}

--- a/scripts/bash/run_tests.sh
+++ b/scripts/bash/run_tests.sh
@@ -4,16 +4,16 @@ GREEN='\033[0;32m'
 SET='\033[0m'
 
 function should_report_to_testomatio {
-  if [ -v "$TESTOMATIO" ]; then
+  if [ -z "$TESTOMATIO" ]; then
     return 1 # Return false
   fi
   if [ "$TESTOMATIO_FORCE_REPORT" == "true" ]; then
     return 0 # Return true since the token is set and the test was marked as force
   fi
-  if [ "$GITHUB_IS_TRIGGERED_BY_PUSH" == "false" ]; then
+  if [ "$TEST_SUITE" == "UnitTests" ]; then
     return 1  # Return false
   fi
-  if [ "$TEST_SUITE" == "UnitTests" ]; then
+  if [ "$GITHUB_EVENT_NAME" != "schedule" ]; then
     return 1 # Return false
   fi
 


### PR DESCRIPTION
### Description

 ### Summary

  This PR updates our GitHub Action test reporting logic so Testomat uploads are triggered by schedule events by default, instead of only push.

  ### Background / Why

  We added scheduled workflow runs in the consuming repository to collect more historical test data and improve flaky-test detection.
  Previously, this action only reported to Testomat when the workflow was triggered by push, so scheduled runs produced no Testomat data. That meant we were missing exactly the repeated, time-based executions needed to identify intermittent failures.

  ### What changed

  - Switched trigger wiring from a push boolean to a single event-name variable:
      - pass GITHUB_EVENT_NAME from action.yml to run_tests.sh
  - Updated should_report_to_testomatio to report when:
      - testomatio token is set
      - event is schedule
      - suite is not UnitTests
      - OR testomatio-force-report=true (override)
  - Kept testomatio-force-report behavior as an explicit override across events.
  - Updated docs/descriptions to reflect new default gating behavior.
  - Fixed token presence check in script logic while making this change.


### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
