### PR TITLE
Add artifact-name-suffix input to disambiguate matrix uploads

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,6 +87,10 @@ inputs:
     description: "Defines if produced build artifacts should be uploaded or not. Only relevant for System, Plugins and UI tests"
     required: false
     default: false
+  artifact-name-suffix:
+    description: "Optional suffix appended to the uploaded artifact_name (e.g. 'bucket-3'). Use to disambiguate uploads from matrix/split jobs that would otherwise overwrite each other on the artifacts server."
+    required: false
+    default: ''
   setup-script:
     description: "Additional setup script to run before starting tests. Can be used by plugin to e.g. set up LDAP or similar."
     required: false
@@ -372,6 +376,7 @@ runs:
         ARTIFACTS_PROTECTED: ${{ inputs.artifacts-protected == 'true' }}
         TEST_SUITE: ${{ inputs.test-type }}
         PLUGIN_NAME: ${{ inputs.plugin-name }}
+        ARTIFACT_NAME_SUFFIX: ${{ inputs.artifact-name-suffix }}
         GITHUB_REPO: ${{ github.repository }}
         GITHUB_BRANCH: ${{ github.head_ref || github.ref_name }}
         GITHUB_RUN_ID: ${{ github.run-id }}

--- a/scripts/bash/upload_artifacts.sh
+++ b/scripts/bash/upload_artifacts.sh
@@ -10,6 +10,14 @@ if [ "$ARTIFACTS_PROTECTED" = "true" ]; then
   url_base="$url_base&protected=1"
 fi
 
+# Suffix appended to every artifact_name uploaded by this script.
+# Lets matrix/split jobs upload to distinct artifact names so the artifacts
+# server (which overwrites on artifact_name collision) does not discard them.
+artifact_name_suffix=""
+if [ -n "$ARTIFACT_NAME_SUFFIX" ]; then
+  artifact_name_suffix=".$ARTIFACT_NAME_SUFFIX"
+fi
+
 if [ "$TEST_SUITE" = "UI" ]; then
   if [ -n "$PLUGIN_NAME" ]; then
     if [ -d "$WORKSPACE/plugins/$PLUGIN_NAME/Test/UI" ]; then
@@ -25,7 +33,7 @@ if [ "$TEST_SUITE" = "UI" ]; then
   ls processed-ui-screenshots
   echo ""
   tar --exclude='.gitkeep' -cjf processed-ui-screenshots.tar.bz2 processed-ui-screenshots
-  curl -X POST --data-binary @processed-ui-screenshots.tar.bz2 "$url_base&artifact_name=processed-screenshots"
+  curl -X POST --data-binary @processed-ui-screenshots.tar.bz2 "$url_base&artifact_name=processed-screenshots$artifact_name_suffix"
   echo "::endgroup::"
 
   # upload diff tarball if it exists
@@ -35,7 +43,7 @@ if [ "$TEST_SUITE" = "UI" ]; then
     ls screenshot-diffs
 
     tar -cjf screenshot-diffs.tar.bz2 screenshot-diffs
-    curl -X POST --data-binary @screenshot-diffs.tar.bz2 "$url_base&artifact_name=screenshot-diffs"
+    curl -X POST --data-binary @screenshot-diffs.tar.bz2 "$url_base&artifact_name=screenshot-diffs$artifact_name_suffix"
     echo "::endgroup::"
   fi
 fi
@@ -43,19 +51,19 @@ fi
 if [ "$TEST_SUITE" = "SystemTestsCore" ]; then
   cd "$WORKSPACE"
   tar --exclude='.gitkeep' -cjf processed.tar.bz2 tests/PHPUnit/System/processed/* --transform 's/.*\///'
-  curl -X POST --data-binary @processed.tar.bz2 "$url_base&artifact_name=system"
+  curl -X POST --data-binary @processed.tar.bz2 "$url_base&artifact_name=system$artifact_name_suffix"
 fi
 
 if [ "$TEST_SUITE" = "SystemTestsPlugins" ]; then
   cd "$WORKSPACE"
   tar --exclude='.gitkeep' -cjf processed.tar.bz2 plugins/*/tests/System/processed/* --transform 's/plugins\///g' --transform 's/\/tests\/System\/processed\//~~/'
-  curl -X POST --data-binary @processed.tar.bz2 "$url_base&artifact_name=system.plugin"
+  curl -X POST --data-binary @processed.tar.bz2 "$url_base&artifact_name=system.plugin$artifact_name_suffix"
 fi
 
 if [ "$TEST_SUITE" = "PluginTests" ]; then
   cd "$WORKSPACE"
   tar --exclude='.gitkeep' -cjf processed.tar.bz2 plugins/$PLUGIN_NAME/tests/System/processed/* --transform "s/plugins\/$PLUGIN_NAME\/tests\/System\/processed\///"
-  curl -X POST --data-binary @processed.tar.bz2 "$url_base&artifact_name=system"
+  curl -X POST --data-binary @processed.tar.bz2 "$url_base&artifact_name=system$artifact_name_suffix"
 fi
 
 echo ""


### PR DESCRIPTION
The artifacts server (builds-artifacts.matomo.org) keys uploads on (build_id, artifact_name) and overwrites on collision. After I split SystemTestsPlugins into 10 bucket matrix jobs, every bucket POSTs to the same artifact_name=system.plugin, so only the last finisher exists.

This adds an optional artifact-name-suffix input that, when set, is appended (dot-separated) to every artifact_name produced by upload_artifacts.sh. Callers from a matrix can pass e.g. artifact-name-suffix: bucket-${{ matrix.bucket }} to land uploads at distinct names like system.plugin.bucket-1 ... system.plugin.bucket-10.

Default empty suffix preserves the existing artifact names verbatim, so non-matrix callers are unaffected.

You can see an example run on `matomo-org/matomo` here https://builds-artifacts.matomo.org/matomo-org/matomo/system_test_artifacts_bundling/26861244877/

Here is the branch: https://github.com/matomo-org/matomo/compare/5.x-dev...system_test_artifacts_bundling
I purposively failed a few tests as well.


### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
