### PR TITLE
pin redis to last known good hash

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -185,8 +185,11 @@ runs:
       if: inputs.redis-service == 'true'
       shell: bash
       run: |
-        docker run -d --name redis -e ALLOW_EMPTY_PASSWORD=yes -p 6379:6379 bitnamisecure/redis:latest
-        docker run -d --name mymaster -e REDIS_MASTER_HOST=localhost -p 26379:26379 bitnamisecure/redis-sentinel:latest
+          # TODO: Revert to :latest once bitnamisecure re-publishes the libredis.sh chmod fix
+          # (https://github.com/bitnami/containers/commit/fb2397d1f8be765c910a48d812515ff09da3a25f).
+          # The current :latest (pushed 2026-06-02) ships 8.8.0-debian-12-r0 which fails container init.
+          docker run -d --name redis -e ALLOW_EMPTY_PASSWORD=yes -p 6379:6379 bitnamisecure/redis@sha256:1347d526ecec0c6537e99eac09e7c3405c21664f6044ff60e78b0898da37abd2
+          docker run -d --name mymaster -e REDIS_MASTER_HOST=localhost -p 26379:26379 bitnamisecure/redis-sentinel@sha256:96317ad4ce459771b81271607afb9c35a7bb50acb7cad26a273e3c1b5fac581e
 
     - name: Resolve PHP version
       id: resolve-php

--- a/action.yml
+++ b/action.yml
@@ -184,12 +184,12 @@ runs:
     - name: start redis services
       if: inputs.redis-service == 'true'
       shell: bash
-      run: |
-          # TODO: Revert to :latest once bitnamisecure re-publishes the libredis.sh chmod fix
-          # (https://github.com/bitnami/containers/commit/fb2397d1f8be765c910a48d812515ff09da3a25f).
-          # The current :latest (pushed 2026-06-02) ships 8.8.0-debian-12-r0 which fails container init.
-          docker run -d --name redis -e ALLOW_EMPTY_PASSWORD=yes -p 6379:6379 bitnamisecure/redis@sha256:1347d526ecec0c6537e99eac09e7c3405c21664f6044ff60e78b0898da37abd2
-          docker run -d --name mymaster -e REDIS_MASTER_HOST=localhost -p 26379:26379 bitnamisecure/redis-sentinel@sha256:96317ad4ce459771b81271607afb9c35a7bb50acb7cad26a273e3c1b5fac581e
+      run: |ß
+        # TODO: Revert to :latest once bitnamisecure re-publishes the libredis.sh chmod fix
+        # (https://github.com/bitnami/containers/commit/fb2397d1f8be765c910a48d812515ff09da3a25f).
+        # The current :latest (pushed 2026-06-02) ships 8.8.0-debian-12-r0 which fails container init.
+        docker run -d --name redis -e ALLOW_EMPTY_PASSWORD=yes -p 6379:6379 bitnamisecure/redis@sha256:1347d526ecec0c6537e99eac09e7c3405c21664f6044ff60e78b0898da37abd2
+        docker run -d --name mymaster -e REDIS_MASTER_HOST=localhost -p 26379:26379 bitnamisecure/redis-sentinel@sha256:96317ad4ce459771b81271607afb9c35a7bb50acb7cad26a273e3c1b5fac581e
 
     - name: Resolve PHP version
       id: resolve-php

--- a/action.yml
+++ b/action.yml
@@ -184,7 +184,7 @@ runs:
     - name: start redis services
       if: inputs.redis-service == 'true'
       shell: bash
-      run: |ß
+      run: |
         # TODO: Revert to :latest once bitnamisecure re-publishes the libredis.sh chmod fix
         # (https://github.com/bitnami/containers/commit/fb2397d1f8be765c910a48d812515ff09da3a25f).
         # The current :latest (pushed 2026-06-02) ships 8.8.0-debian-12-r0 which fails container init.


### PR DESCRIPTION
### Description

`matomo-org/matomo` CI run with this branch passing: https://github.com/matomo-org/matomo/actions/runs/26852617268 

Pin the redis and redis-sentinel images used by `redis-service: true` to the previously published digests. The current `bitnamisecure/redis:latest` and `bitnamisecure/redis-sentinel:latest` (re-published 2026-06-02) fail to start in our CIrunners; an [upstream fix](https://github.com/bitnami/containers/commit/fb2397d1f8be765c910a48d812515ff09da3a25f) has landed but has not yet been re-published to `:latest`. Pinning unblocks CI until `:latest` is healthy.

## What's skipped by the pin

All Redis upstream CVEs published in this window were fixed in 8.6.3 (the pinned version), so there is no known CVE delta. The skipped rebuilds are base-image refreshes; given these images are short-lived CI services bound to localhost on runners with no persistent data, the exposure is negligible imho open to other opinions🤷 

## Future:

Should we just use the official redis images what have semver and we can pin to a stable release for this?
And then have to have some custom setup for redis sentinel 

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
