### PR TITLE
Pull docker images via mirror.gcr.io to avoid Docker Hub rate limits

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -115,7 +115,7 @@ runs:
           -p 3306:3306 \
           -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
           -e MYSQL_DATABASE=matomo_tests \
-          mysql:${{ inputs.mysql-version || '5.7' }}
+          mirror.gcr.io/library/mysql:${{ inputs.mysql-version || '5.7' }}
 
         for i in $(seq 1 30); do
           if mysqladmin ping -h127.0.0.1 -uroot --silent; then
@@ -142,7 +142,7 @@ runs:
           -p 3306:3306 \
           -e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 \
           -e MARIADB_DATABASE=matomo_tests \
-          mariadb:${{ inputs.mysql-version || 'latest' }}
+          mirror.gcr.io/library/mariadb:${{ inputs.mysql-version || 'latest' }}
 
         for i in $(seq 1 30); do
           if mysqladmin ping -h127.0.0.1 -uroot --silent; then
@@ -164,7 +164,7 @@ runs:
       run: |
         docker run -d \
           -p 3306:4000 \
-          pingcap/tidb:${{ inputs.mysql-version || 'latest' }}
+          mirror.gcr.io/pingcap/tidb:${{ inputs.mysql-version || 'latest' }}
 
         for i in $(seq 1 30); do
           if mysqladmin ping -h127.0.0.1 -uroot --silent; then
@@ -188,8 +188,8 @@ runs:
         # TODO: Revert to :latest once bitnamisecure re-publishes the libredis.sh chmod fix
         # (https://github.com/bitnami/containers/commit/fb2397d1f8be765c910a48d812515ff09da3a25f).
         # The current :latest (pushed 2026-06-02) ships 8.8.0-debian-12-r0 which fails container init.
-        docker run -d --name redis -e ALLOW_EMPTY_PASSWORD=yes -p 6379:6379 bitnamisecure/redis@sha256:1347d526ecec0c6537e99eac09e7c3405c21664f6044ff60e78b0898da37abd2
-        docker run -d --name mymaster -e REDIS_MASTER_HOST=localhost -p 26379:26379 bitnamisecure/redis-sentinel@sha256:96317ad4ce459771b81271607afb9c35a7bb50acb7cad26a273e3c1b5fac581e
+        docker run -d --name redis -e ALLOW_EMPTY_PASSWORD=yes -p 6379:6379 mirror.gcr.io/bitnamisecure/redis@sha256:1347d526ecec0c6537e99eac09e7c3405c21664f6044ff60e78b0898da37abd2
+        docker run -d --name mymaster -e REDIS_MASTER_HOST=localhost -p 26379:26379 mirror.gcr.io/bitnamisecure/redis-sentinel@sha256:96317ad4ce459771b81271607afb9c35a7bb50acb7cad26a273e3c1b5fac581e
 
     - name: Resolve PHP version
       id: resolve-php


### PR DESCRIPTION
## Summary

Route every `docker run` in `action.yml` through Google's public Docker Hub pull-through cache (`mirror.gcr.io`) instead of anonymous Docker Hub.

| Was | Now |
|---|---|
| `mysql:<ver>` | `mirror.gcr.io/library/mysql:<ver>` |
| `mariadb:<ver>` | `mirror.gcr.io/library/mariadb:<ver>` |
| `pingcap/tidb:<ver>` | `mirror.gcr.io/pingcap/tidb:<ver>` |
| `bitnamisecure/redis@sha256:…` | `mirror.gcr.io/bitnamisecure/redis@sha256:…` |
| `bitnamisecure/redis-sentinel@sha256:…` | `mirror.gcr.io/bitnamisecure/redis-sentinel@sha256:…` |

## Why

Matomo CI runs hit Docker Hub's anonymous pull cap and Docker Hub registry timeouts under sustained load.

**Docker Hub limits** (anonymous = 100 pulls / 6h per source IP, see https://docs.docker.com/docker-hub/usage/ and https://docs.docker.com/docker-hub/usage/pulls/). GitHub-hosted runners share egress IP ranges across customers, so the org effectively shares a quota with everyone else on the same runner subnet.

**Example failure in matomo-org/matomo CI:** https://github.com/matomo-org/matomo/actions/runs/27315422903/job/80694800306 — `PHP (SystemTestsPlugins, bucket 3/10, 7.2, PDO_MYSQL, Mysql, 5.7)` died at the `start mysql services` step with:

```
Unable to find image 'mysql:5.7' locally
docker: Error response from daemon: Get "https://registry-1.docker.io/v2/": context deadline exceeded
##[error]Process completed with exit code 125.
```

This is a Docker Hub-side failure mode (registry timeout under load, correlated with throttling) — exactly the class of problem a pull-through cache eliminates.

**`mirror.gcr.io`** is Google's free public Docker Hub mirror — anonymous, no published per-IP cap, and Docker itself documents it as a recommended registry mirror. Image layout is `docker.io/<repo>` → `mirror.gcr.io/<repo>` (and `docker.io/library/<x>` → `mirror.gcr.io/library/<x>`). SHA-pinned digests are portable across registries, so the bitnami pins are unchanged in content.

## Verification

All five image references were probed via the registry v2 manifest API (HTTP 200), then exercised in a real Matomo Tests CI run on a test branch:

- ✅ Successful build (4/5 images exercised end-to-end across 145 jobs): https://github.com/caddoo/matomo/actions/runs/27315837297

In that run, every job's `start mysql/mariadb/redis services` step pulled cleanly from `mirror.gcr.io` (e.g. `Status: Downloaded newer image for mirror.gcr.io/library/mysql:5.7`). `pingcap/tidb` is not exercised by the Matomo Tests matrix but its manifest API returned 200 and the swap is the same trivial host substitution.

Two jobs in that run did fail (`UI-core (1)`, `UI-plugins (SegmentEditor)`) — both were downstream UI spec failures (`1 failing` after dozens of passing specs), unrelated to docker pulls and reproducible on plain `5.x-dev`.

## Notes

- `mirror.gcr.io` is a *pull-through* cache: brand-new Docker Hub tags can 404 briefly until first populated by an upstream pull. The bitnami SHA pins don't have this risk; for `:latest` tags this is essentially never an issue at our scale.
- No behaviour change beyond the registry host. Image contents and tags are identical.