### PR TITLE
Adds code to fallback to 5.x-dev instead of 4.x-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This action is able to run certain test suites for Matomo or any Matomo plugin.
 
       If a version is defined in `plugin.json` this version will be tried to check out. If e.g. `>=4.0.0-b1,<5.0.0-b1` is defined it will try to check out `4.0.0-b1`.
 
-      In case the defined version can not be found. e.g. the tag `4.0.0-b1` is not available, it will first try to check out the stable version (if beta provided). e.g. `4.0.0` in this example. If that would also fail it falls back to the development branch of that major version. So `4.x-dev` in that case.
+      In case the defined version can not be found. e.g. the tag `4.0.0-b1` is not available, it will first try to check out the stable version (if beta provided). e.g. `4.0.0` in this example. If that would also fail it falls back to the development branch of that major version. If that branch does not exist either, it falls back to `5.x-dev`.
 
     - **maximum_supported_matomo**
 

--- a/scripts/bash/checkout_test_against_branch.sh
+++ b/scripts/bash/checkout_test_against_branch.sh
@@ -9,9 +9,9 @@ if [[ "$MATOMO_TEST_TARGET" == "minimum_required_matomo" && "$PLUGIN_NAME" != ""
 
       export MATOMO_TEST_TARGET=${MATOMO_TEST_TARGET%-*}
     elif ! git ls-remote --exit-code origin "${MATOMO_TEST_TARGET:0:1}.x-dev" >/dev/null 2>&1; then
-      echo "Could not find development branch '${MATOMO_TEST_TARGET:0:1}.x-dev' for '$MATOMO_TEST_TARGET' specified in plugin.json, testing against 4.x-dev."
+      echo "Could not find development branch '${MATOMO_TEST_TARGET:0:1}.x-dev' for '$MATOMO_TEST_TARGET' specified in plugin.json, testing against 5.x-dev."
 
-      export MATOMO_TEST_TARGET=4.x-dev
+      export MATOMO_TEST_TARGET=5.x-dev
     else
       echo "Could not find tag '$MATOMO_TEST_TARGET' specified in plugin.json, testing against development branch ${MATOMO_TEST_TARGET:0:1}.x-dev."
 
@@ -23,9 +23,9 @@ elif [[ "$MATOMO_TEST_TARGET" == "maximum_supported_matomo" && "$PLUGIN_NAME" !=
 
   if ! git ls-remote --exit-code origin "$MATOMO_TEST_TARGET" >/dev/null 2>&1; then
     if ! git ls-remote --exit-code origin "${MATOMO_TEST_TARGET:0:1}.x-dev" >/dev/null 2>&1; then
-      echo "Could not find development branch '${MATOMO_TEST_TARGET:0:1}.x-dev' for '$MATOMO_TEST_TARGET' specified in plugin.json, testing against 4.x-dev."
+      echo "Could not find development branch '${MATOMO_TEST_TARGET:0:1}.x-dev' for '$MATOMO_TEST_TARGET' specified in plugin.json, testing against 5.x-dev."
 
-      export MATOMO_TEST_TARGET=4.x-dev
+      export MATOMO_TEST_TARGET=5.x-dev
     else
       echo "Could not find tag '$MATOMO_TEST_TARGET' specified in plugin.json, testing against development branch ${MATOMO_TEST_TARGET:0:1}.x-dev."
 

--- a/scripts/php/get_required_matomo_version.php
+++ b/scripts/php/get_required_matomo_version.php
@@ -6,9 +6,10 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-$pathToMatomo     = $argv[1];
-$pluginName       = $argv[2];
-$returnMaxVersion = !empty($argv[3]) && $argv[3] === 'max';
+$pathToMatomo        = $argv[1];
+$pluginName          = $argv[2];
+$returnMaxVersion    = !empty($argv[3]) && $argv[3] === 'max';
+$defaultDevFallback  = '5.x-dev';
 
 // tiny script to get plugin version from plugin.json from a bash script
 require_once $pathToMatomo . '/core/Version.php';
@@ -86,12 +87,11 @@ function getMaxVersion(array $requiredVersions): string
 
         if ($comparison == '<' && preg_match('/^[2-9]\.0\.0-b1$/', $version)) {
             $majorVersion = (int)substr($version, 0, 1) - 1;
-            $maxVersion   = trim(
-                file_get_contents(
-                    'https://api.matomo.org/1.0/getLatestVersion/?release_channel=latest_' . $majorVersion . 'x_beta'
-                )
-            );
             $devBranch    = $majorVersion . '.x-dev';
+            $maxVersion   = @file_get_contents(
+                'https://api.matomo.org/1.0/getLatestVersion/?release_channel=latest_' . $majorVersion . 'x_beta'
+            );
+            $maxVersion   = $maxVersion === false ? '' : trim($maxVersion);
 
             if (empty($maxVersion) || !version_compare($version, $maxVersion, '<=')) {
                 // use dev branch if the latest released version is covered by the supported version
@@ -134,7 +134,7 @@ if ($returnMaxVersion) {
 if (empty($versionToReturn)) {
     $requiredVersions = $allRequiredVersions;
     $versionToReturn  = getMinVersion($requiredVersions);
-    $versionToReturn  = !empty($versionToReturn) ? $versionToReturn : '4.x-dev';
+    $versionToReturn  = !empty($versionToReturn) ? $versionToReturn : $defaultDevFallback;
 }
 
 echo $versionToReturn;


### PR DESCRIPTION
### Description

Adds code to fallback to 5.x-dev instead of 4.x-dev, currently seeing the `https://api.matomo.org/1.0/getLatestVersion/?release_channel=latest_5x_beta` throwing 403 intermittently on builds and the code fallbacks to 4.x-dev, which fails the plugin test.

Changed to fallback to 5.x-dev instead.

This will reduce false positives due to 403 error.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
