### PR TITLE
Fix issues with lfs and composer auth

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -296,6 +296,7 @@ runs:
         PLUGIN_NAME: ${{ inputs.plugin-name }}
         WORKSPACE: ${{ github.workspace }}
         ACTION_PATH: ${{ github.action_path }}
+        COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ github.token }}"}}'
 
     - name: checkout additional plugins
       if: inputs.dependent-plugins != ''

--- a/scripts/bash/prepare.sh
+++ b/scripts/bash/prepare.sh
@@ -12,9 +12,13 @@ echo -e "${GREEN}Using workspace path $WORKSPACE ${SET}"
 
 if [ "$TEST_SUITE" = "UI" ]; then
   cd $WORKSPACE/matomo
-  git lfs pull --exclude=
   if [ "$PLUGIN_NAME" != '' ]; then
+    # Plugin builds only compare the plugin's own screenshots, so skip Matomo
+    # core's screenshots (~124MB) and scope the plugin's pull to its UI dir.
     cd $WORKSPACE/matomo/plugins/$PLUGIN_NAME
+    git lfs pull --include="tests/UI/expected-screenshots/*" --exclude=
+  else
+    # Matomo core build: the calling workflow scopes via `git config lfs.fetchinclude`.
     git lfs pull --exclude=
   fi
   echo -e "${GREEN}setup fonts${SET}"


### PR DESCRIPTION
### Description
### Issue 1:
We initially had an issue with lfs failing because we were pulling all our screenshot LFS for every job we did. This made us encounter our LFS limit. 

We have added a fix in core so that we only pull the plugin's LFS screenshot on the job its doing it on. We just want premium plugins to get this fix as well.

### Issue 2
We also have an issue where our 8.2 and 8.5 System and Integration tests failing. This was actually caused by compose
#### Root cause
For PHP 8.x, `scripts/bash/prepare.sh` bumps phpunit via
`composer remove --dev phpunit/phpunit` then
`composer require --dev phpunit/phpunit ~9.3 ...`.
The `require` re-resolves the tree, which makes composer fetch commit
metadata for `dev-master`-pinned deps (e.g. `matomo-org/matomo-coding-standards`)
from `api.github.com`. Those requests were **unauthenticated**, so GitHub
returned an **HTTP 429 anti-scraping throttle**:

We have made the fix here to add in our github token when we do composer require. 



### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
