### PR TITLE
Fix PHP 8 test failures caused by GitHub API throttling during PHPUnit install

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -296,6 +296,7 @@ runs:
         PLUGIN_NAME: ${{ inputs.plugin-name }}
         WORKSPACE: ${{ github.workspace }}
         ACTION_PATH: ${{ github.action_path }}
+        GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
 
     - name: checkout additional plugins
       if: inputs.dependent-plugins != ''

--- a/scripts/bash/prepare.sh
+++ b/scripts/bash/prepare.sh
@@ -33,9 +33,8 @@ fi
 
 cd $WORKSPACE/matomo
 echo -e "${GREEN}composer install${SET}"
-# Authenticate composer against the GitHub API to avoid the unauthenticated rate
-# limit (60 req/hour). Resolving dev/commit refs (e.g. matomo-coding-standards)
-# during `composer require`/`install` otherwise returns HTTP 429 throttling.
+# Authenticate composer so GitHub API/git requests are not subject to the
+# unauthenticated 60 req/hour limit (and so private repos can be cloned).
 if [ -n "$GITHUB_TOKEN" ]; then
   composer config --global github-oauth.github.com "$GITHUB_TOKEN"
 fi
@@ -45,6 +44,13 @@ composer install --ignore-platform-reqs
 
 # use PHPUnit 9.x for PHP 8.x
 if [[ "$PHP_VERSION" == "8."* ]]; then
+  # The PHPUnit swap re-resolves the dependency graph, which makes composer
+  # refresh commit metadata for GitHub-hosted dev-master packages (e.g.
+  # matomo-coding-standards) via api.github.com/.../commits/<sha>. That endpoint
+  # hits GitHub's secondary (anti-scraping) rate limit and returns HTTP 429 even
+  # for authenticated requests, aborting the install. Reading that metadata from
+  # a local git clone instead avoids the GitHub API entirely.
+  composer config --global use-github-api false
   composer remove --dev phpunit/phpunit
   # made sure that phpunit version chooses 1.5.0 for doctrine/instantiator
   # because the next version 2.0 introduces incompatible code to php 8.2

--- a/scripts/bash/prepare.sh
+++ b/scripts/bash/prepare.sh
@@ -33,6 +33,12 @@ fi
 
 cd $WORKSPACE/matomo
 echo -e "${GREEN}composer install${SET}"
+# Authenticate composer against the GitHub API to avoid the unauthenticated rate
+# limit (60 req/hour). Resolving dev/commit refs (e.g. matomo-coding-standards)
+# during `composer require`/`install` otherwise returns HTTP 429 throttling.
+if [ -n "$GITHUB_TOKEN" ]; then
+  composer config --global github-oauth.github.com "$GITHUB_TOKEN"
+fi
 # prevents possible error with older Matomo releases, that doesn't include that config
 composer config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer false
 composer install --ignore-platform-reqs


### PR DESCRIPTION
## Problem

PHP 8 test jobs fail with `exit code 127` (e.g. [this run](https://github.com/matomo-org/matomo/actions/runs/28360011604/job/84012181813)). The `127` is `./vendor/phpunit/phpunit/phpunit: command not found` in `run_tests.sh` — PHPUnit was never installed.

The root cause is **GitHub's secondary (anti-scraping) rate limit**, not a PHPUnit version conflict. From the job log, the failure sequence is:

1. `composer install` (from the lock file) **succeeds** — all packages extract fine.
2. `composer remove --dev phpunit/phpunit` **succeeds**.
3. The PHP-8 PHPUnit swap runs:
   ```bash
   composer require --dev phpunit/phpunit ~9.3 doctrine/instantiator:^1.5.0 --ignore-platform-reqs
   ```
   which expands to `composer update phpunit/phpunit doctrine/instantiator`. To rewrite the lock file, composer refreshes the **commit date** of the `dev-master` packages (e.g. `matomo-coding-standards`) via `api.github.com/.../commits/<sha>`:
   ```
   The "https://api.github.com/repos/matomo-org/matomo-coding-standards/commits/19bdc..."
   file could not be downloaded (HTTP/2 429):
   "This endpoint is temporarily being throttled. Please try again later.
    For more on scraping GitHub ... Terms of Service"
   ```
   → install aborts and reverts → no phpunit binary → `run_tests.sh` exits `127`.

### Why a token alone does not fix it

The first attempt added composer `github-oauth` auth. Testing showed the token **is** passed (`GITHUB_TOKEN: ***` in the log) and composer **still** 429s. The throttled endpoint is GitHub's *secondary* anti-abuse limit (note the "throttled / scraping / Terms of Service" wording), which applies to authenticated requests too. Scoping the update to PHPUnit doesn't help either — the command is already scoped to `phpunit/phpunit doctrine/instantiator`, but the **lock rewrite** still forces a commit-date lookup for every `dev-master` package.

## Fix

Change **how** composer reads that commit metadata, not which packages it touches. Around the PHP-8 PHPUnit swap, set:

```bash
composer config --global use-github-api false
```

With this, composer treats GitHub repos like any git repo and reads the commit date from a **local git clone** (`git log`) instead of `api.github.com` — so the swap never calls the throttled endpoint.

- Scoped to the PHP-8 block only, so the locked `composer install` is untouched and keeps using fast dist (zip) downloads.
- Only the handful of `dev-master` packages get resolved via git during the swap — a small, deterministic cost.
- The `github-oauth` token is kept as well: it still helps with git/HTTPS auth and the primary rate limit, it's just not sufficient on its own.

## Validation

Tested against matomo branch `testactiontest2`, which points its workflow at `matomo-org/github-action-tests@fix-composer-github-api-rate-limit`.

## Follow-up (out of scope)

A cleaner long-term option is to pin `matomo-coding-standards` to a tagged release instead of `dev-master` in matomo's `composer.json`, eliminating the commit-date lookup entirely.