### PR TITLE
Add reusable PHPCS and AI-checklist workflows for plugin repos, PG-4897

### DIFF
--- a/.github/workflows/plugin-ai-checklist.yml
+++ b/.github/workflows/plugin-ai-checklist.yml
@@ -22,4 +22,4 @@ jobs:
       fail-fast: false
     steps:
       - name: Run tests
-        uses: matomo-org/github-action-checklist-gate@main
+        uses: matomo-org/github-action-checklist-gate@d5f101a2538ef30ddb3b06cc366f852c9851b588 # main as of 2026-08-04

--- a/.github/workflows/plugin-ai-checklist.yml
+++ b/.github/workflows/plugin-ai-checklist.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   AiChecklist:
+    name: AI checklist gate
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false

--- a/.github/workflows/plugin-ai-checklist.yml
+++ b/.github/workflows/plugin-ai-checklist.yml
@@ -1,0 +1,25 @@
+name: AI Checklist
+
+on:
+  workflow_call: {}
+
+permissions:
+  actions: read
+  checks: none
+  contents: none
+  deployments: none
+  issues: none
+  packages: none
+  pull-requests: read
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+jobs:
+  AiChecklist:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Run tests
+        uses: matomo-org/github-action-checklist-gate@main

--- a/.github/workflows/plugin-ai-checklist.yml
+++ b/.github/workflows/plugin-ai-checklist.yml
@@ -3,17 +3,11 @@ name: AI Checklist
 on:
   workflow_call: {}
 
+# The gate reads the pull request description; callers must grant these two
+# scopes in their own permissions block.
 permissions:
   actions: read
-  checks: none
-  contents: none
-  deployments: none
-  issues: none
-  packages: none
   pull-requests: read
-  repository-projects: none
-  security-events: none
-  statuses: none
 
 jobs:
   AiChecklist:

--- a/.github/workflows/plugin-phpcs.yml
+++ b/.github/workflows/plugin-phpcs.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           PLUGIN_NAME: ${{ inputs.plugin-name }}
         run:
-          composer init --name=matomo/$(echo "$PLUGIN_NAME" | tr '[:upper:]' '[:lower:]') --quiet;
+          composer init --name="matomo/$(echo "$PLUGIN_NAME" | tr '[:upper:]' '[:lower:]')" --quiet;
           composer --no-plugins config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true -n;
           composer config repositories.matomo-coding-standards vcs https://github.com/matomo-org/matomo-coding-standards -n;
           composer require matomo-org/matomo-coding-standards:dev-master;

--- a/.github/workflows/plugin-phpcs.yml
+++ b/.github/workflows/plugin-phpcs.yml
@@ -30,6 +30,15 @@ jobs:
     name: PHPCS
     runs-on: ubuntu-24.04
     steps:
+      - name: Validate inputs
+        env:
+          PLUGIN_NAME: ${{ inputs.plugin-name }}
+        run: |
+          if [[ ! "$PLUGIN_NAME" =~ ^[A-Za-z0-9_]+$ ]]; then
+            echo "Invalid plugin-name: $PLUGIN_NAME"
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
         with:
           lfs: false

--- a/.github/workflows/plugin-phpcs.yml
+++ b/.github/workflows/plugin-phpcs.yml
@@ -40,8 +40,10 @@ jobs:
           php-version: ${{ inputs.php-version }}
           tools: cs2pr
       - name: Install dependencies
+        env:
+          PLUGIN_NAME: ${{ inputs.plugin-name }}
         run:
-          composer init --name=matomo/$(echo '${{ inputs.plugin-name }}' | tr '[:upper:]' '[:lower:]') --quiet;
+          composer init --name=matomo/$(echo "$PLUGIN_NAME" | tr '[:upper:]' '[:lower:]') --quiet;
           composer --no-plugins config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true -n;
           composer config repositories.matomo-coding-standards vcs https://github.com/matomo-org/matomo-coding-standards -n;
           composer require matomo-org/matomo-coding-standards:dev-master;

--- a/.github/workflows/plugin-phpcs.yml
+++ b/.github/workflows/plugin-phpcs.yml
@@ -13,17 +13,10 @@ on:
         type: string
         default: '7.4'
 
+# The job only reads the repository; everything else stays at none so any caller
+# with default workflow permissions can use this without granting scopes.
 permissions:
-  actions: read
-  checks: read
   contents: read
-  deployments: none
-  issues: read
-  packages: none
-  pull-requests: read
-  repository-projects: none
-  security-events: none
-  statuses: read
 
 jobs:
   phpcs:

--- a/.github/workflows/plugin-phpcs.yml
+++ b/.github/workflows/plugin-phpcs.yml
@@ -1,0 +1,54 @@
+name: PHPCS check
+
+on:
+  workflow_call:
+    inputs:
+      plugin-name:
+        description: "Name of the plugin, e.g. LoginLdap"
+        required: true
+        type: string
+      php-version:
+        description: "PHP version the job runs on"
+        required: false
+        type: string
+        default: '7.4'
+
+permissions:
+  actions: read
+  checks: read
+  contents: read
+  deployments: none
+  issues: read
+  packages: none
+  pull-requests: read
+  repository-projects: none
+  security-events: none
+  statuses: read
+
+jobs:
+  phpcs:
+    name: PHPCS
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: false
+          persist-credentials: false
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: ${{ inputs.php-version }}
+          tools: cs2pr
+      - name: Install dependencies
+        run:
+          composer init --name=matomo/$(echo '${{ inputs.plugin-name }}' | tr '[:upper:]' '[:lower:]') --quiet;
+          composer --no-plugins config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true -n;
+          composer config repositories.matomo-coding-standards vcs https://github.com/matomo-org/matomo-coding-standards -n;
+          composer require matomo-org/matomo-coding-standards:dev-master;
+          composer install --dev --prefer-dist --no-progress --no-suggest
+      - name: Check PHP code styles
+        id: phpcs
+        run: ./vendor/bin/phpcs --report-full --standard=phpcs.xml --report-checkstyle=./phpcs-report.xml
+      - name: Show PHPCS results in PR
+        if: ${{ always() && steps.phpcs.outcome == 'failure' }}
+        run: cs2pr ./phpcs-report.xml --prepend-filename

--- a/.github/workflows/plugin-phpcs.yml
+++ b/.github/workflows/plugin-phpcs.yml
@@ -39,7 +39,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           lfs: false
           persist-credentials: false

--- a/README.md
+++ b/README.md
@@ -186,3 +186,11 @@ jobs:
   AiChecklist:
     uses: matomo-org/github-action-tests/.github/workflows/plugin-ai-checklist.yml@main
 ```
+
+Both examples use `@main` to match how plugin repositories currently consume this repository.
+For immutability, pin the `uses:` reference to a full commit SHA — release tags stay mutable
+unless the repository enforces immutable releases:
+
+```yaml
+    uses: matomo-org/github-action-tests/.github/workflows/plugin-phpcs.yml@<full commit SHA>
+```

--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ name: AI Checklist
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
+permissions:
+  actions: read
+  pull-requests: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/README.md
+++ b/README.md
@@ -154,3 +154,35 @@ This action is able to run certain test suites for Matomo or any Matomo plugin.
           dependent-plugins: 'slug/plugin-AdditionalPlugin'
           github-token: ${{ secrets.TESTS_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
 ```
+
+### PHPCS (`.github/workflows/plugin-phpcs.yml`)
+
+Runs the plugin's own `phpcs.xml` against the matomo-coding-standards ruleset. Inputs:
+`plugin-name` (required), `php-version` (optional, default `7.4`).
+
+```yaml
+name: PHPCS check
+on: pull_request
+jobs:
+  phpcs:
+    uses: matomo-org/github-action-tests/.github/workflows/plugin-phpcs.yml@main
+    with:
+      plugin-name: MyPlugin
+```
+
+### AI Checklist (`.github/workflows/plugin-ai-checklist.yml`)
+
+Runs the org's checklist gate against the pull request description. No inputs.
+
+```yaml
+name: AI Checklist
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  AiChecklist:
+    uses: matomo-org/github-action-tests/.github/workflows/plugin-ai-checklist.yml@main
+```


### PR DESCRIPTION
### Description

Extends the centralization started in #44 to the two remaining plugin workflows that are effectively identical across repositories:

- **`plugin-phpcs.yml`** — the per-plugin `phpcs.yml` copies differ only in the lowercased plugin name passed to `composer init` and in drifted PHP versions (7.4 vs 8.1 across repos today); both become inputs. The setup-php action is pinned by hash, matching #44.
- **`plugin-ai-checklist.yml`** — the per-plugin `matomo-ai-checklist.yml` is byte-identical in every repo that has one, and some repos simply lack it (ApiReference only gained it recently); a reusable workflow makes adoption a 7-line caller.

Caller shape, respectively:

```yaml
name: PHPCS check
on: pull_request
jobs:
  phpcs:
    uses: matomo-org/github-action-tests/.github/workflows/plugin-phpcs.yml@main
    with:
      plugin-name: MyPlugin
```

```yaml
name: AI Checklist
on:
  pull_request:
    types: [opened, synchronize, reopened, edited]
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
jobs:
  AiChecklist:
    uses: matomo-org/github-action-tests/.github/workflows/plugin-ai-checklist.yml@main
```

**Deliberately excluded: `matomo-tests.yml`.** It is generated by core's `./console generate:test-action` and genuinely varies per plugin (custom PHP version matrices, `--setup-script`, `--has-submodules`, `--protect-artifacts`, per-repo cron schedules). Its centralization path is evolving the generator to emit a thin caller of a reusable workflow, which is a core change and should be its own ticket.

README documentation for these two will follow in #44 or after it merges, to avoid conflicting edits to the same README section.

Ticket: PG-4897.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
