### PR TITLE
Add matomo6_min_php and matomo6_max_php PHP version aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This action is able to run certain test suites for Matomo or any Matomo plugin.
 
     Defines the PHP version to set up for testing. (Not needed for Client tests)
 
-    Use `matomo5_min_php` or `matomo5_max_php` to resolve to the centrally managed (defined in action.yml) minimum or maximum PHP versions supported by Matomo tests.
+    Use `matomo5_min_php`/`matomo5_max_php` (Matomo 5) or `matomo6_min_php`/`matomo6_max_php` (Matomo 6) to resolve to the centrally managed (defined in action.yml) minimum or maximum PHP versions supported by Matomo tests.
 
     The action uses `shivammathur/setup-php` to set up PHP. You can find supported PHP versions here: https://github.com/shivammathur/setup-php#tada-php-support
 

--- a/action.yml
+++ b/action.yml
@@ -202,6 +202,12 @@ runs:
           matomo5_max_php)
             RESOLVED_VERSION="8.5"
             ;;
+          matomo6_min_php)
+            RESOLVED_VERSION="8.1"
+            ;;
+          matomo6_max_php)
+            RESOLVED_VERSION="8.5"
+            ;;
           '')
             exit 0
             ;;


### PR DESCRIPTION
### Description

Adds `matomo6_min_php` and `matomo6_max_php` aliases, resolving to PHP 8.1 (the Matomo 6 minimum) and PHP 8.5, alongside the existing `matomo5_*` aliases. Plugin repositories' Matomo 6 branches can then switch their test matrices with a mechanical `matomo5_` → `matomo6_` rename while the supported PHP range stays centrally managed here, matching how the Matomo 5 aliases are used today. First consumer is the ActivityLog Matomo 6 branch (PG-5380).

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
