### PR TITLE
Generate minimum-Matomo compatibility checks into plugin test runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,13 @@ This action is able to run certain test suites for Matomo or any Matomo plugin.
 
     For security reasons this option should not be provided in plain text, but using a repository secret instead.
 
+  * **skip-generated-checks**
+
+    Before running plugin integration tests, this action generates compatibility checks into the plugin's test directory that compile the plugin's stylesheets and templates against the Matomo version under test. That catches a plugin using a core Less mixin or Twig function newer than the minimum Matomo its plugin.json declares, which would otherwise only surface once users on an older Matomo install the release.
+
+    Set this to true to skip generating them. This is an escape hatch, not a way to keep a real incompatibility unfixed: the two valid fixes are to stop using the newer core API, or to raise the required Matomo version in plugin.json.
+
+
   * **setup-script**
 
     This option can contain the path to a bash script that should be executed before running the tests.

--- a/action.yml
+++ b/action.yml
@@ -99,6 +99,11 @@ inputs:
     description: "Flag for whether to force uploading a report to Testomat.io instead of just push events. Only applies if the 'testomatio' token is set."
     required: false
     default: false
+  skip-generated-checks:
+    type: boolean
+    description: "If true, the compatibility checks this action generates into the plugin's integration tests are not written. Escape hatch only."
+    required: false
+    default: false
 
 runs:
   using: "composite"
@@ -331,6 +336,17 @@ runs:
       shell: bash
       run: sudo apt-get install ripgrep
       working-directory: ${{ github.workspace }}/matomo
+
+    - name: Generate plugin compatibility checks
+      if: inputs.plugin-name != ''
+      working-directory: ${{ github.workspace }}/matomo
+      shell: bash
+      run: ${{ github.action_path }}/scripts/bash/generate_compatibility_checks.sh
+      env:
+        TEST_SUITE: ${{ inputs.test-type }}
+        PLUGIN_NAME: ${{ inputs.plugin-name }}
+        ACTION_PATH: ${{ github.action_path }}
+        SKIP_GENERATED_CHECKS: ${{ inputs.skip-generated-checks }}
 
     - name: Run tests
       working-directory: ${{ github.workspace }}/matomo

--- a/scripts/bash/generate_compatibility_checks.sh
+++ b/scripts/bash/generate_compatibility_checks.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+SET='\033[0m'
+
+if [ -z "$PLUGIN_NAME" ]; then
+  exit 0
+fi
+
+if [ "$SKIP_GENERATED_CHECKS" == "true" ]; then
+  echo -e "${YELLOW}skip-generated-checks is set, not generating compatibility checks${SET}"
+  exit 0
+fi
+
+# only these suites include plugins/*/tests/Integration, see tests/PHPUnit/phpunit.xml.dist
+case "$TEST_SUITE" in
+  PluginTests|IntegrationTestsPlugins) ;;
+  *)
+    echo "Test suite '$TEST_SUITE' does not run plugin integration tests, not generating compatibility checks"
+    exit 0
+    ;;
+esac
+
+# same precedence as run_tests.sh uses to pick the directory it hands to phpunit
+if [ -d "plugins/$PLUGIN_NAME/Test" ]; then
+  TARGET_DIR="plugins/$PLUGIN_NAME/Test/Integration"
+elif [ -d "plugins/$PLUGIN_NAME/tests" ]; then
+  TARGET_DIR="plugins/$PLUGIN_NAME/tests/Integration"
+else
+  echo "Plugin $PLUGIN_NAME has no test directory, not generating compatibility checks"
+  exit 0
+fi
+
+mkdir -p "$TARGET_DIR"
+
+for template in "$ACTION_PATH"/scripts/php/templates/Generated*.php.tpl; do
+  target="$TARGET_DIR/$(basename "$template" .tpl)"
+
+  sed "s/{{PLUGIN_NAME}}/$PLUGIN_NAME/g" "$template" > "$target"
+
+  echo -e "${GREEN}Generated $target${SET}"
+  cat "$target"
+done

--- a/scripts/php/templates/GeneratedAssetCompilationTest.php.tpl
+++ b/scripts/php/templates/GeneratedAssetCompilationTest.php.tpl
@@ -22,7 +22,6 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
  * mixin or variable that does not exist yet in the Matomo version under test fails here rather
  * than fatally on every page of an install running that version.
  *
- * @group {{PLUGIN_NAME}}
  * @group Plugins
  */
 class GeneratedAssetCompilationTest extends IntegrationTestCase

--- a/scripts/php/templates/GeneratedAssetCompilationTest.php.tpl
+++ b/scripts/php/templates/GeneratedAssetCompilationTest.php.tpl
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ * GENERATED FILE - do not commit this to the plugin repository.
+ * It is written into the plugin checkout during CI by matomo-org/github-action-tests.
+ * To change it, edit scripts/php/templates/GeneratedAssetCompilationTest.php.tpl in that repository.
+ */
+
+namespace Piwik\Plugins\{{PLUGIN_NAME}}\tests\Integration;
+
+use Piwik\AssetManager;
+use Piwik\Plugin\Manager;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * Compiles the merged stylesheet with the plugin loaded, so that a plugin using a core Less
+ * mixin or variable that does not exist yet in the Matomo version under test fails here rather
+ * than fatally on every page of an install running that version.
+ *
+ * @group {{PLUGIN_NAME}}
+ * @group Plugins
+ */
+class GeneratedAssetCompilationTest extends IntegrationTestCase
+{
+    private const PLUGIN_NAME = '{{PLUGIN_NAME}}';
+
+    public function testStylesheetsCompileAgainstTheMatomoVersionUnderTest()
+    {
+        // the test framework decides which plugin to load from this class' namespace, so a
+        // wrongly generated namespace would leave the plugin out and make the merge below pass
+        // no matter what the plugin ships
+        self::assertTrue(
+            Manager::getInstance()->isPluginLoaded(self::PLUGIN_NAME),
+            self::PLUGIN_NAME . ' is not loaded, so this check would not cover the plugin.'
+        );
+
+        $assetManager = AssetManager::getInstance();
+        $assetManager->removeMergedAssets();
+
+        self::assertNotEmpty($assetManager->getMergedStylesheet()->getContent());
+    }
+}

--- a/scripts/php/templates/GeneratedTwigCompilationTest.php.tpl
+++ b/scripts/php/templates/GeneratedTwigCompilationTest.php.tpl
@@ -28,7 +28,6 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
  * may therefore write the template engine's namespace with a space in front of it, which is why
  * the environment is built from an inline \Piwik\Twig below rather than an imported short name.
  *
- * @group {{PLUGIN_NAME}}
  * @group Plugins
  */
 class GeneratedTwigCompilationTest extends IntegrationTestCase

--- a/scripts/php/templates/GeneratedTwigCompilationTest.php.tpl
+++ b/scripts/php/templates/GeneratedTwigCompilationTest.php.tpl
@@ -75,15 +75,12 @@ class GeneratedTwigCompilationTest extends IntegrationTestCase
                 continue;
             }
 
-            $name = str_replace('\\', '/', substr($file->getPathname(), strlen($templateDir) + 1));
-
-            // templates/plugins/<Other>/ holds theme overrides that are registered under the
-            // other plugin's namespace, so they are not this plugin's to compile
-            if (strpos($name, 'plugins/') === 0) {
-                continue;
-            }
-
-            $names[] = $name;
+            // theme overrides under templates/plugins/<Other>/ are included: the plugin's own
+            // namespace is rooted at templates/, so this reaches the override file itself. Their
+            // registered namespace is only added for the theme that is currently enabled, which
+            // the plugin under test is not, so addressing them that way would compile the
+            // overridden plugin's copy instead of the file shipped here.
+            $names[] = str_replace('\\', '/', substr($file->getPathname(), strlen($templateDir) + 1));
         }
 
         sort($names);

--- a/scripts/php/templates/GeneratedTwigCompilationTest.php.tpl
+++ b/scripts/php/templates/GeneratedTwigCompilationTest.php.tpl
@@ -15,14 +15,18 @@ namespace Piwik\Plugins\{{PLUGIN_NAME}}\tests\Integration;
 
 use Piwik\Plugin\Manager;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
-use Piwik\Twig;
 
 /**
- * Compiles every template the plugin ships, so that a template using a core Twig function,
- * filter or tag that does not exist yet in the Matomo version under test fails here rather than
- * when a user opens the page on an install running that version.
+ * Compiles every template the plugin ships, so that one using a core template function, filter
+ * or tag that does not exist yet in the Matomo version under test fails here rather than when a
+ * user opens the page on an install running that version.
  *
  * Only compilation is covered. Undefined variables are a runtime concern and are not reported.
+ *
+ * Core's tests:check-direct-dependency-use greps plugin files for a vendor namespace preceded by
+ * a space, and most plugins assert an exact list of the files it matches. Nothing in this file
+ * may therefore write the template engine's namespace with a space in front of it, which is why
+ * the environment is built from an inline \Piwik\Twig below rather than an imported short name.
  *
  * @group {{PLUGIN_NAME}}
  * @group Plugins
@@ -40,15 +44,14 @@ class GeneratedTwigCompilationTest extends IntegrationTestCase
             self::markTestSkipped(self::PLUGIN_NAME . ' ships no templates.');
         }
 
-        // the plugin's own Twig extensions are only registered while it is loaded, and the test
-        // framework decides what to load from this class' namespace
+        // the plugin's own template extensions are only registered while it is loaded, and the
+        // test framework decides what to load from this class' namespace
         self::assertTrue(
             Manager::getInstance()->isPluginLoaded(self::PLUGIN_NAME),
             self::PLUGIN_NAME . ' is not loaded, so this check would not cover the plugin.'
         );
 
-        $twig        = new Twig();
-        $environment = $twig->getTwigEnvironment();
+        $environment = (new \Piwik\Twig())->getTwigEnvironment();
 
         foreach ($templates as $template) {
             $environment->load('@' . self::PLUGIN_NAME . '/' . $template);
@@ -75,7 +78,7 @@ class GeneratedTwigCompilationTest extends IntegrationTestCase
 
             $name = str_replace('\\', '/', substr($file->getPathname(), strlen($templateDir) + 1));
 
-            // templates/plugins/<Other>/ holds theme overrides that Twig registers under the
+            // templates/plugins/<Other>/ holds theme overrides that are registered under the
             // other plugin's namespace, so they are not this plugin's to compile
             if (strpos($name, 'plugins/') === 0) {
                 continue;

--- a/scripts/php/templates/GeneratedTwigCompilationTest.php.tpl
+++ b/scripts/php/templates/GeneratedTwigCompilationTest.php.tpl
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ * GENERATED FILE - do not commit this to the plugin repository.
+ * It is written into the plugin checkout during CI by matomo-org/github-action-tests.
+ * To change it, edit scripts/php/templates/GeneratedTwigCompilationTest.php.tpl in that repository.
+ */
+
+namespace Piwik\Plugins\{{PLUGIN_NAME}}\tests\Integration;
+
+use Piwik\Plugin\Manager;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Twig;
+
+/**
+ * Compiles every template the plugin ships, so that a template using a core Twig function,
+ * filter or tag that does not exist yet in the Matomo version under test fails here rather than
+ * when a user opens the page on an install running that version.
+ *
+ * Only compilation is covered. Undefined variables are a runtime concern and are not reported.
+ *
+ * @group {{PLUGIN_NAME}}
+ * @group Plugins
+ */
+class GeneratedTwigCompilationTest extends IntegrationTestCase
+{
+    private const PLUGIN_NAME = '{{PLUGIN_NAME}}';
+
+    public function testTemplatesCompileAgainstTheMatomoVersionUnderTest()
+    {
+        $templateDir = PIWIK_DOCUMENT_ROOT . '/plugins/' . self::PLUGIN_NAME . '/templates';
+        $templates   = is_dir($templateDir) ? $this->getTemplateNames($templateDir) : [];
+
+        if (empty($templates)) {
+            self::markTestSkipped(self::PLUGIN_NAME . ' ships no templates.');
+        }
+
+        // the plugin's own Twig extensions are only registered while it is loaded, and the test
+        // framework decides what to load from this class' namespace
+        self::assertTrue(
+            Manager::getInstance()->isPluginLoaded(self::PLUGIN_NAME),
+            self::PLUGIN_NAME . ' is not loaded, so this check would not cover the plugin.'
+        );
+
+        $twig        = new Twig();
+        $environment = $twig->getTwigEnvironment();
+
+        foreach ($templates as $template) {
+            $environment->load('@' . self::PLUGIN_NAME . '/' . $template);
+        }
+
+        self::assertNotEmpty($templates);
+    }
+
+    /**
+     * @return string[] template names relative to the plugin's templates directory
+     */
+    private function getTemplateNames(string $templateDir): array
+    {
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($templateDir, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        $names = [];
+
+        foreach ($iterator as $file) {
+            if ($file->getExtension() !== 'twig') {
+                continue;
+            }
+
+            $name = str_replace('\\', '/', substr($file->getPathname(), strlen($templateDir) + 1));
+
+            // templates/plugins/<Other>/ holds theme overrides that Twig registers under the
+            // other plugin's namespace, so they are not this plugin's to compile
+            if (strpos($name, 'plugins/') === 0) {
+                continue;
+            }
+
+            $names[] = $name;
+        }
+
+        sort($names);
+
+        return $names;
+    }
+}


### PR DESCRIPTION
### Description

Plugin CI already runs `PluginTests` against the minimum Matomo a plugin declares in `plugin.json`, but nothing in that suite compiles stylesheets or templates. A plugin can therefore use a core Less mixin or Twig function that only exists in a newer Matomo, pass every check, and fatal on every page for anyone running an older version. That is what happened in CustomReports (PG-5029): a `.inDarkMode({...})` block shipped against `require.matomo: ">=5.0.0-rc5"` while the mixin only landed in Matomo 5.11.0, so the admin UI died with `.inDarkMode is undefined in anonymous-file-0.less` on 5.0–5.10.

This adds the missing coverage centrally rather than asking every plugin repository to copy a test file in. Before running phpunit, the action writes small integration tests into the plugin checkout from templates in `scripts/php/templates/`:

- **`GeneratedAssetCompilationTest`** compiles the merged stylesheet with the plugin loaded, so a Less mixin or variable that does not exist in the Matomo under test fails here instead of in production.
- **`GeneratedTwigCompilationTest`** compiles every template the plugin ships, so a core Twig function, filter or tag that does not exist yet fails the same way. Plugins with no templates report a skip.

Because these land in `plugins/<Plugin>/tests/Integration/`, they run inside the existing `minimum_required_matomo` matrix leg — no new job and no extra CI minutes. Nothing changes in any plugin repository, and adding further checks later only requires another `Generated*.php.tpl`, which the generator picks up automatically.

A core test file could not do this: the min-version leg checks out an old core tag, so anything added to core today is simply absent exactly where the check is needed.

**Scope of effect.** The generation step is skipped entirely unless `plugin-name` is set, so Matomo core's own workflows are unaffected — they scope plugin work through `ui-test-options` and `phpunit-test-options` and never pass `plugin-name`. It is also skipped for suites that do not run plugin integration tests, when the plugin has no test directory, and when the new `skip-generated-checks` input is set.

**Verified on real CI**, not just locally. Six plugin workflows were pointed at this branch and dispatched: CustomReports, CustomAlerts, Funnels, FormAnalytics, HeatmapSessionRecording and TagManager — chosen for the largest Less and Twig surface. Every one of the ten `minimum_required_matomo` legs passed, each reporting `Testing against '5.0.0-rc5'` and running both generated checks against that core. TagManager's 884-test run reports no skips, so its 17 templates were genuinely compiled rather than skipped. The only red in the sweep was a known-flaky `APITest` in HeatmapSessionRecording, on a `maximum_supported_matomo` leg, unrelated to these checks.

That is six of roughly 46 plugins, so a plugin outside the sample could still be sitting on a real incompatibility. That is the check doing its job rather than a regression, and `skip-generated-checks` is the escape hatch if one needs to be unblocked while it is fixed.

Two details worth knowing when editing the templates:

- The test class namespace is what makes the framework load the plugin. With a generic namespace the plugin is not loaded, the merge covers core only, and the check passes while testing nothing — so both templates assert `isPluginLoaded()` and fail loudly rather than silently.
- `tests:check-direct-dependency-use` greps plugin files for a vendor namespace preceded by a space, and most plugins assert an exact list of the files it matches. Generated code must never name a vendor namespace that way. The first pilot run failed on exactly this, and the templates now document the constraint.

Related: PG-5221.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
