### PR TITLE
Init submodules not during clone

### DIFF
--- a/scripts/bash/checkout_matomo.sh
+++ b/scripts/bash/checkout_matomo.sh
@@ -15,7 +15,7 @@ if [ "$PLUGIN_NAME" != '' ]; then
   cp -R !($PLUGIN_NAME) $PLUGIN_NAME
 
   echo -e "${GREEN}Clone Matomo repo${SET}"
-  git clone -q --recurse-submodules https://github.com/matomo-org/matomo
+  git clone -q https://github.com/matomo-org/matomo
   git fetch -q --all
   cd $WORKSPACE/matomo
 


### PR DESCRIPTION
### Description

We moved a plugin to  core that previously was a submodule. This causes problems in case the initial clone already fetches the submodules, as it fails to remove it, when trying to switch to 6.x-dev afterwards.

As submodules are initialized after the branch switch anyway, there is not need to fetch them with the initial clone.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
